### PR TITLE
fix: change author tag to supertag

### DIFF
--- a/zotero-translator-tana-cf.js
+++ b/zotero-translator-tana-cf.js
@@ -4,7 +4,7 @@
   "label":"Tana Metadata Export - CortexFutura",
   "creator":"CortexFutura based on Stian Haklev's,Joel Chan's, and Joshua Hall's work",
   "target":"md",
-  "minVersion":"2.0",
+  "minVersion":"2.1",
   "maxVersion":"",
   "priority":200,
   "inRepository":false,
@@ -39,10 +39,10 @@
         for (author in item.creators){
           if (item.creators[author].firstName !== undefined && item.creators[author].lastName !== undefined) {
             // Use the full name of the author. Should be the most common situation
-            Zotero.write('    - [[' + (item.creators[author].firstName || '') + ' ' + (item.creators[author].lastName || '') + ']] #[[Author]]\n');
+            Zotero.write('    - ' + (item.creators[author].firstName || '') + ' ' + (item.creators[author].lastName || '') + ' #Author\n');
           } else if (item.creators[author].lastName !== undefined) {
             // Only use the last name
-            Zotero.write('    - [[' (item.creators[author].lastName || '') + ']] #[[Author]]\n');
+            Zotero.write('    - ' (item.creators[author].lastName || '') + ' #Author\n');
           } else {
             // Hypothetically impossible unless your DB is inconsistent for some reason
             Zotero.write('    - Unknown author');


### PR DESCRIPTION
The author attributes were previously links with the tag also linked. 

`- [[Joe Bloggs]] #[[Author]]`

When this is pasted in Tana, I found that the tag didn't properly apply. Therefore, I've removed the link around the author's name and the supertag.

Now when the content is pasted in Tana, the #author supertag is properly applied to the author's name